### PR TITLE
Backend community specific data type creation

### DIFF
--- a/purposeful-community-cloud/pom.xml
+++ b/purposeful-community-cloud/pom.xml
@@ -80,7 +80,11 @@
 			<artifactId>mapstruct-processor</artifactId>
 			<version>${org.mapstruct.version}</version>
 		</dependency>
-
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-collections4</artifactId>
+			<version>4.1</version>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-mail</artifactId>

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/constant/FieldType.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/constant/FieldType.java
@@ -1,0 +1,10 @@
+package com.evteam.purposefulcommunitycloud.constant;
+
+public enum FieldType {
+    TEXT,
+    NUMBER,
+    DECIMAL,
+    DATE,
+    LOCATION,
+    TIME
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
@@ -31,7 +31,8 @@ public class CSDataController {
     @Autowired
     private JwtResolver jwtResolver;
 
-    @ApiOperation(value = "Create community specific data template with the needed information", response = DataTemplateResource.class)
+    @ApiOperation(value = "Create community specific data template with the needed information. Field types are TEXT,NUMBER, DECIMAL,DATE,LOCATION,TIME",
+            response = DataTemplateResource.class)
     @PostMapping("/create-csd")
     public ResponseEntity<DataTemplateResource> createCSDTemplate(@RequestHeader String token, @RequestBody DataTemplateDto templateDto) {
         return ResponseEntity.ok(service.createCSDTemplate(templateDto, jwtResolver.getIdFromToken(token)));

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
@@ -1,16 +1,17 @@
 package com.evteam.purposefulcommunitycloud.controller;
 
 import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
+import com.evteam.purposefulcommunitycloud.model.resource.DataFieldResource;
 import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
 import com.evteam.purposefulcommunitycloud.service.CSDataService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Created by Emir Gökdemir
@@ -29,4 +30,17 @@ public class CSDataController {
     public ResponseEntity<DataTemplateResource> createCSDTemplate(@RequestBody DataTemplateDto templateDto){
         return ResponseEntity.ok(service.createCSDTemplate(templateDto));
     }
+
+    @ApiOperation(value = "Get community specific data template with id", response = DataTemplateResource.class)
+    @GetMapping("/{id}")
+    public ResponseEntity<DataTemplateResource> getCSDTemplate(@PathVariable("id")UUID id){
+        return ResponseEntity.ok(service.getCSDTemplate(id));
+    }
+
+    @ApiOperation(value = "Get fields of community specific data template with id of data template", response = DataFieldResource.class)
+    @GetMapping("/fields/{id}")
+    public ResponseEntity<Set<DataFieldResource>> getFieldsOfCSDTemplate(@PathVariable("id")UUID id){
+        return ResponseEntity.ok(service.getFieldsOfCSDTemplate(id));
+    }
+
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
@@ -1,8 +1,10 @@
 package com.evteam.purposefulcommunitycloud.controller;
 
 import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
+import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
 import com.evteam.purposefulcommunitycloud.model.resource.DataFieldResource;
 import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
+import com.evteam.purposefulcommunitycloud.security.JwtResolver;
 import com.evteam.purposefulcommunitycloud.service.CSDataService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -10,6 +12,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -25,22 +28,31 @@ public class CSDataController {
     @Autowired
     private CSDataService service;
 
+    @Autowired
+    private JwtResolver jwtResolver;
+
     @ApiOperation(value = "Create community specific data template with the needed information", response = DataTemplateResource.class)
     @PostMapping("/create-csd")
-    public ResponseEntity<DataTemplateResource> createCSDTemplate(@RequestBody DataTemplateDto templateDto){
-        return ResponseEntity.ok(service.createCSDTemplate(templateDto));
+    public ResponseEntity<DataTemplateResource> createCSDTemplate(@RequestHeader String token, @RequestBody DataTemplateDto templateDto) {
+        return ResponseEntity.ok(service.createCSDTemplate(templateDto, jwtResolver.getIdFromToken(token)));
     }
 
     @ApiOperation(value = "Get community specific data template with id", response = DataTemplateResource.class)
     @GetMapping("/{id}")
-    public ResponseEntity<DataTemplateResource> getCSDTemplate(@PathVariable("id")UUID id){
-        return ResponseEntity.ok(service.getCSDTemplate(id));
+    public ResponseEntity<DataTemplateResource> getCSDTemplate(@RequestHeader String token, @PathVariable("id") UUID id) {
+        return ResponseEntity.ok(service.getCSDTemplate(id, jwtResolver.getIdFromToken(token)));
     }
 
     @ApiOperation(value = "Get fields of community specific data template with id of data template", response = DataFieldResource.class)
     @GetMapping("/fields/{id}")
-    public ResponseEntity<Set<DataFieldResource>> getFieldsOfCSDTemplate(@PathVariable("id")UUID id){
-        return ResponseEntity.ok(service.getFieldsOfCSDTemplate(id));
+    public ResponseEntity<Set<DataFieldResource>> getFieldsOfCSDTemplate(@RequestHeader String token, @PathVariable("id") UUID id) {
+        return ResponseEntity.ok(service.getFieldsOfCSDTemplate(id, jwtResolver.getIdFromToken(token)));
+    }
+
+    @ApiOperation(value = "Get data templates of a community with id of community", response = DataTemplateResource.class)
+    @GetMapping("/get-community-templates/{community-id}")
+    public ResponseEntity<List<DataTemplateResource>> getCSDTemplateOfCommunity(@RequestHeader String token, @PathVariable("community-id") UUID id) {
+        return ResponseEntity.ok(service.getCommunityTemplates(id, jwtResolver.getIdFromToken(token)));
     }
 
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
@@ -25,7 +25,7 @@ public class CSDataController {
     @Autowired
     private CSDataService service;
 
-    @ApiOperation(value = "Save community specific data template with the needed information", response = DataTemplateResource.class)
+    @ApiOperation(value = "Create community specific data template with the needed information", response = DataTemplateResource.class)
     @PostMapping("/create-csd")
     public ResponseEntity<DataTemplateResource> createCSDTemplate(@RequestBody DataTemplateDto templateDto){
         return ResponseEntity.ok(service.createCSDTemplate(templateDto));

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CSDataController.java
@@ -1,0 +1,32 @@
+package com.evteam.purposefulcommunitycloud.controller;
+
+import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
+import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
+import com.evteam.purposefulcommunitycloud.service.CSDataService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+@RestController
+@RequestMapping(value = {"/data-template"})
+@Api(value = "Community Specific Data", tags = {"Community Specific Data Operations"})
+public class CSDataController {
+
+    @Autowired
+    private CSDataService service;
+
+    @ApiOperation(value = "Save community specific data template with the needed information", response = DataTemplateResource.class)
+    @PostMapping("/create-csd")
+    public ResponseEntity<DataTemplateResource> createCSDTemplate(@RequestBody DataTemplateDto templateDto){
+        return ResponseEntity.ok(service.createCSDTemplate(templateDto));
+    }
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CommunityController.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/controller/CommunityController.java
@@ -1,0 +1,45 @@
+package com.evteam.purposefulcommunitycloud.controller;
+
+import com.evteam.purposefulcommunitycloud.model.dto.CommunityDto;
+import com.evteam.purposefulcommunitycloud.model.resource.CommunityResource;
+import com.evteam.purposefulcommunitycloud.security.JwtResolver;
+import com.evteam.purposefulcommunitycloud.service.CommunityService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+@RestController
+@RequestMapping(value = {"/community"})
+@Api(value = "Community", tags = {"Community Operations"})
+public class CommunityController {
+
+    @Autowired
+    private JwtResolver jwtResolver;
+
+    @Autowired
+    private CommunityService service;
+
+    @ApiOperation(value = "Create community with the needed information", response = CommunityResource.class)
+    @PostMapping("/create")
+    public ResponseEntity<CommunityResource> create(@RequestBody CommunityDto dto,
+                                                    @RequestHeader String token){
+        return ResponseEntity.ok(service.createCommunity(dto,jwtResolver.getIdFromToken(token)));
+    }
+
+    @ApiOperation(value = "Get community with the token, for now private communities can be acccesed by only creator.", response = CommunityResource.class)
+    @GetMapping("/get/{id}")
+    public ResponseEntity<CommunityResource> get(@RequestHeader String token,@PathVariable("id") UUID communityId){
+        return ResponseEntity.ok(service.getCommunity(communityId,jwtResolver.getIdFromToken(token)));
+    }
+
+
+
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/CommunityMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/CommunityMapper.java
@@ -1,0 +1,25 @@
+package com.evteam.purposefulcommunitycloud.mapper;
+
+import com.evteam.purposefulcommunitycloud.common.Converter;
+import com.evteam.purposefulcommunitycloud.model.dto.CommunityDto;
+import com.evteam.purposefulcommunitycloud.model.entity.Community;
+import com.evteam.purposefulcommunitycloud.model.resource.CommunityResource;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.Set;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE)
+public interface CommunityMapper extends Converter<CommunityDto, Community, CommunityResource> {
+
+//
+//    @Mapping(source = "templates", target = "templateResources")
+//    CommunityResource toResource(Community community);
+
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataFieldMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataFieldMapper.java
@@ -1,0 +1,13 @@
+package com.evteam.purposefulcommunitycloud.mapper;
+
+
+import com.evteam.purposefulcommunitycloud.common.Converter;
+import com.evteam.purposefulcommunitycloud.model.dto.DataFieldDto;
+import com.evteam.purposefulcommunitycloud.model.entity.DataField;
+import com.evteam.purposefulcommunitycloud.model.resource.DataFieldResource;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE)
+public interface DataFieldMapper extends Converter<DataFieldDto, DataField, DataFieldResource> {
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataFieldMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataFieldMapper.java
@@ -8,6 +8,12 @@ import com.evteam.purposefulcommunitycloud.model.resource.DataFieldResource;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.Set;
+
+
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE)
 public interface DataFieldMapper extends Converter<DataFieldDto, DataField, DataFieldResource> {
+
+    Set<DataFieldResource> toResource(Set<DataField> fields);
+
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
@@ -1,0 +1,12 @@
+package com.evteam.purposefulcommunitycloud.mapper;
+
+import com.evteam.purposefulcommunitycloud.common.Converter;
+import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
+import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
+import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE)
+public interface DataTemplateMapper extends Converter<DataTemplateDto, DataTemplate, DataTemplateResource> {
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
@@ -8,12 +8,14 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE,uses = {DataFieldMapper.class})
 public interface DataTemplateMapper extends Converter<DataTemplateDto, DataTemplate, DataTemplateResource> {
 
     @Mapping(source = "fields", target = "fieldResources")
     DataTemplateResource toResource(DataTemplate dataTemplate);
-//
-//    Set<DataTemplateResource> toResource(Set<DataTemplate> templates);
+
+    List<DataTemplateResource> toResource(List<DataTemplate> templates);
 
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
@@ -5,8 +5,12 @@ import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
 import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
 import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 
-@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE)
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE,unmappedSourcePolicy = ReportingPolicy.IGNORE,uses = {DataFieldMapper.class})
 public interface DataTemplateMapper extends Converter<DataTemplateDto, DataTemplate, DataTemplateResource> {
+
+    @Mapping(source = "fields", target = "fieldResources")
+    DataTemplateResource toResource(DataTemplate dataTemplate);
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/mapper/DataTemplateMapper.java
@@ -13,4 +13,7 @@ public interface DataTemplateMapper extends Converter<DataTemplateDto, DataTempl
 
     @Mapping(source = "fields", target = "fieldResources")
     DataTemplateResource toResource(DataTemplate dataTemplate);
+//
+//    Set<DataTemplateResource> toResource(Set<DataTemplate> templates);
+
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/CommunityDto.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/CommunityDto.java
@@ -1,0 +1,22 @@
+package com.evteam.purposefulcommunitycloud.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommunityDto {
+    private String name;
+    private String description;
+    private Integer size;
+    private Boolean isPrivate;
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/DataFieldDto.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/DataFieldDto.java
@@ -1,0 +1,20 @@
+package com.evteam.purposefulcommunitycloud.model.dto;
+
+import com.evteam.purposefulcommunitycloud.constant.FieldType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DataFieldDto {
+    private String name;
+    private FieldType fieldType;
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/DataTemplateDto.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/DataTemplateDto.java
@@ -1,0 +1,28 @@
+package com.evteam.purposefulcommunitycloud.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Created by Emir Gökdemir
+ * on 16 Kas 2019
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DataTemplateDto  {
+
+    private String name;
+
+    // TODO: 16 Kas 2019 community will be added
+
+    private UUID userId;
+
+    private Set<DataFieldDto> fields;
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/DataTemplateDto.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/dto/DataTemplateDto.java
@@ -20,9 +20,9 @@ public class DataTemplateDto  {
 
     private String name;
 
-    // TODO: 16 Kas 2019 community will be added
-
     private UUID userId;
 
     private Set<DataFieldDto> fields;
+
+    private UUID communityId;
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/Community.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/Community.java
@@ -1,7 +1,6 @@
 package com.evteam.purposefulcommunitycloud.model.entity;
 
 import com.evteam.purposefulcommunitycloud.common.AbstractEntity;
-import com.evteam.purposefulcommunitycloud.constant.FieldType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -11,21 +10,30 @@ import javax.validation.constraints.NotNull;
 
 /**
  * Created by Emir Gökdemir
- * on 16 Kas 2019
+ * on 17 Kas 2019
  */
-@Data
 @Entity
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "data_field")
-public class DataField extends AbstractEntity {
+@Table(name = "community")
+public class Community extends AbstractEntity {
 
     @NotNull
+    @Column(name = "name")
     private String name;
 
-    @Enumerated(EnumType.STRING)
-    private FieldType fieldType;
+    @NotNull
+    @Column(name = "description")
+    private String description;
 
-//    @ManyToMany(mappedBy = "fields")
-//    Set<DataTemplate> templates;
+    @Column(name = "size")
+    private Integer size;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    User creator;
+
+    @Column(name = "is_private")
+    private Boolean isPrivate;
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/DataField.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/DataField.java
@@ -1,0 +1,33 @@
+package com.evteam.purposefulcommunitycloud.model.entity;
+
+import com.evteam.purposefulcommunitycloud.common.AbstractEntity;
+import com.evteam.purposefulcommunitycloud.constant.FieldType;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+
+/**
+ * Created by Emir Gökdemir
+ * on 16 Kas 2019
+ */
+@Data
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "data_field")
+public class DataField extends AbstractEntity {
+
+    @NotNull
+    private String name;
+
+    // TODO: 17 Kas 2019  community eklenecek
+
+    @Enumerated(EnumType.STRING)
+    private FieldType fieldType;
+
+//    @ManyToMany(mappedBy = "fields")
+//    Set<DataTemplate> templates;
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/DataTemplate.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/DataTemplate.java
@@ -20,7 +20,9 @@ public class DataTemplate extends AbstractEntity {
     @NotNull
     String name;
 
-    // TODO: 16 Kas 2019  community will be added
+    @ManyToOne
+    @JoinColumn(name = "community_id")
+    Community community;
 
     @ManyToOne
     @JoinColumn(name = "user_id")

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/DataTemplate.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/entity/DataTemplate.java
@@ -1,0 +1,34 @@
+package com.evteam.purposefulcommunitycloud.model.entity;
+
+import com.evteam.purposefulcommunitycloud.common.AbstractEntity;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+/**
+ * Created by Emir Gökdemir
+ * on 16 Kas 2019
+ */
+@Data
+@Entity
+@NoArgsConstructor
+@Table(name = "data_template")
+public class DataTemplate extends AbstractEntity {
+    @NotNull
+    String name;
+
+    // TODO: 16 Kas 2019  community will be added
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    User creator;
+
+    @ManyToMany
+            @JoinTable(name="template_include_fields",
+            joinColumns = @JoinColumn(name = "template_id"),
+            inverseJoinColumns = @JoinColumn(name = "field_id"))
+    Set<DataField> fields;
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/CommunityResource.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/CommunityResource.java
@@ -1,0 +1,38 @@
+package com.evteam.purposefulcommunitycloud.model.resource;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.annotation.Resource;
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+
+@Resource
+@AllArgsConstructor
+@Getter
+@Setter
+@NoArgsConstructor
+public class CommunityResource {
+
+    UUID id;
+
+    private ZonedDateTime createdDate;
+
+    private ZonedDateTime lastModifiedDate;
+
+    private String name;
+
+    private String description;
+
+    private Integer size;
+
+    private Boolean isPrivate;
+
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataFieldResource.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataFieldResource.java
@@ -1,0 +1,28 @@
+package com.evteam.purposefulcommunitycloud.model.resource;
+
+import com.evteam.purposefulcommunitycloud.model.entity.DataField;
+import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
+
+import javax.annotation.Resource;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+@Resource
+public class DataFieldResource {
+
+    UUID id;
+
+    private ZonedDateTime createdDate;
+
+    private ZonedDateTime modifiedDate;
+
+    private String name;
+
+    private Set<DataTemplate> templates;
+
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataFieldResource.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataFieldResource.java
@@ -1,11 +1,12 @@
 package com.evteam.purposefulcommunitycloud.model.resource;
 
-import com.evteam.purposefulcommunitycloud.model.entity.DataField;
-import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.annotation.Resource;
 import java.time.ZonedDateTime;
-import java.util.Set;
 import java.util.UUID;
 
 /**
@@ -13,16 +14,18 @@ import java.util.UUID;
  * on 17 Kas 2019
  */
 @Resource
+@AllArgsConstructor
+@Getter
+@Setter
+@NoArgsConstructor
 public class DataFieldResource {
 
     UUID id;
 
     private ZonedDateTime createdDate;
 
-    private ZonedDateTime modifiedDate;
+    private ZonedDateTime lastModifiedDate;
 
     private String name;
-
-    private Set<DataTemplate> templates;
 
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataTemplateResource.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataTemplateResource.java
@@ -22,10 +22,10 @@ public class DataTemplateResource {
 
     private ZonedDateTime createdDate;
 
-    private ZonedDateTime modifiedDate;
+    private ZonedDateTime lastModifiedDate;
 
     private String name;
 
-    private Set<DataField> fields;
+    private Set<DataFieldResource> fieldResources;
 
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataTemplateResource.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/model/resource/DataTemplateResource.java
@@ -1,0 +1,31 @@
+package com.evteam.purposefulcommunitycloud.model.resource;
+
+import com.evteam.purposefulcommunitycloud.model.entity.DataField;
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.annotation.Resource;
+import java.time.ZonedDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Created by Emir Gökdemir
+ * on 16 Kas 2019
+ */
+@Resource
+@Setter
+@Getter
+public class DataTemplateResource {
+
+    private UUID id;
+
+    private ZonedDateTime createdDate;
+
+    private ZonedDateTime modifiedDate;
+
+    private String name;
+
+    private Set<DataField> fields;
+
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/CommunityRepository.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/CommunityRepository.java
@@ -1,0 +1,11 @@
+package com.evteam.purposefulcommunitycloud.repository;
+
+import com.evteam.purposefulcommunitycloud.model.entity.Community;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface CommunityRepository extends JpaRepository<Community, UUID> {
+
+    Community findCommunityById(UUID id);
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataFieldRepository.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataFieldRepository.java
@@ -1,0 +1,11 @@
+package com.evteam.purposefulcommunitycloud.repository;
+
+import com.evteam.purposefulcommunitycloud.model.entity.DataField;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface DataFieldRepository extends JpaRepository<DataField, UUID> {
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataTemplateRepository.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataTemplateRepository.java
@@ -1,0 +1,12 @@
+package com.evteam.purposefulcommunitycloud.repository;
+
+import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface DataTemplateRepository extends JpaRepository<DataTemplate, UUID> {
+
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataTemplateRepository.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataTemplateRepository.java
@@ -1,12 +1,15 @@
 package com.evteam.purposefulcommunitycloud.repository;
 
+import com.evteam.purposefulcommunitycloud.model.entity.Community;
 import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface DataTemplateRepository extends JpaRepository<DataTemplate, UUID> {
     DataTemplate findDataTemplateById(UUID id);
+    List<DataTemplate> findDataTemplatesByCommunity(Community community);
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataTemplateRepository.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/DataTemplateRepository.java
@@ -8,5 +8,5 @@ import java.util.UUID;
 
 @Repository
 public interface DataTemplateRepository extends JpaRepository<DataTemplate, UUID> {
-
+    DataTemplate findDataTemplateById(UUID id);
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/UserRepository.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     User findByEmail(String email);
 
+    User findUserById(UUID id);
+
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
@@ -1,0 +1,52 @@
+package com.evteam.purposefulcommunitycloud.service;
+
+import com.evteam.purposefulcommunitycloud.mapper.DataFieldMapper;
+import com.evteam.purposefulcommunitycloud.mapper.DataTemplateMapper;
+import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
+import com.evteam.purposefulcommunitycloud.model.entity.DataField;
+import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
+import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
+import com.evteam.purposefulcommunitycloud.repository.DataFieldRepository;
+import com.evteam.purposefulcommunitycloud.repository.DataTemplateRepository;
+import com.evteam.purposefulcommunitycloud.repository.UserRepository;
+import org.apache.commons.collections4.CollectionUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+/**
+ * Created by Emir Gökdemir
+ * on 16 Kas 2019
+ */
+@Service
+public class CSDataService {
+
+    @Autowired
+    private DataTemplateMapper templateMapper;
+
+    @Autowired
+    private DataFieldMapper fieldMapper;
+
+    @Autowired
+    private DataFieldRepository fieldRepository;
+
+    @Autowired
+    private DataTemplateRepository templateRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Transactional
+    public DataTemplateResource createCSDTemplate(DataTemplateDto templateDto) {
+
+        DataTemplate dataTemplate=templateMapper.toEntity(templateDto);
+        dataTemplate.setCreator(userRepository.findUserById(templateDto.getUserId()));
+        dataTemplate.setCreator(userRepository.findUserById(templateDto.getUserId()));
+        for(DataField field: CollectionUtils.emptyIfNull(dataTemplate.getFields())){
+            fieldRepository.saveAndFlush(field);
+        }
+        templateRepository.save(dataTemplate);
+        return templateMapper.toResource(dataTemplate);
+    }
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
@@ -5,6 +5,7 @@ import com.evteam.purposefulcommunitycloud.mapper.DataTemplateMapper;
 import com.evteam.purposefulcommunitycloud.model.dto.DataTemplateDto;
 import com.evteam.purposefulcommunitycloud.model.entity.DataField;
 import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
+import com.evteam.purposefulcommunitycloud.model.resource.DataFieldResource;
 import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
 import com.evteam.purposefulcommunitycloud.repository.DataFieldRepository;
 import com.evteam.purposefulcommunitycloud.repository.DataTemplateRepository;
@@ -14,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.Set;
+import java.util.UUID;
 
 /**
  * Created by Emir Gökdemir
@@ -48,5 +51,13 @@ public class CSDataService {
         }
         templateRepository.save(dataTemplate);
         return templateMapper.toResource(dataTemplate);
+    }
+
+    public DataTemplateResource getCSDTemplate(UUID id) {
+        return templateMapper.toResource(templateRepository.findDataTemplateById(id));
+    }
+
+    public Set<DataFieldResource> getFieldsOfCSDTemplate(UUID id) {
+        return templateMapper.toResource(templateRepository.findDataTemplateById(id)).getFieldResources();
     }
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
@@ -7,6 +7,7 @@ import com.evteam.purposefulcommunitycloud.model.entity.DataField;
 import com.evteam.purposefulcommunitycloud.model.entity.DataTemplate;
 import com.evteam.purposefulcommunitycloud.model.resource.DataFieldResource;
 import com.evteam.purposefulcommunitycloud.model.resource.DataTemplateResource;
+import com.evteam.purposefulcommunitycloud.repository.CommunityRepository;
 import com.evteam.purposefulcommunitycloud.repository.DataFieldRepository;
 import com.evteam.purposefulcommunitycloud.repository.DataTemplateRepository;
 import com.evteam.purposefulcommunitycloud.repository.UserRepository;
@@ -15,6 +16,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
+import java.util.List;
 import java.util.Set;
 import java.util.UUID;
 
@@ -40,23 +42,30 @@ public class CSDataService {
     @Autowired
     private UserRepository userRepository;
 
-    @Transactional
-    public DataTemplateResource createCSDTemplate(DataTemplateDto templateDto) {
+    @Autowired
+    private CommunityRepository communityRepository;
 
-        DataTemplate dataTemplate=templateMapper.toEntity(templateDto);
+    @Transactional
+    public DataTemplateResource createCSDTemplate(DataTemplateDto templateDto, UUID userId) {
+        DataTemplate dataTemplate = templateMapper.toEntity(templateDto);
         dataTemplate.setCreator(userRepository.findUserById(templateDto.getUserId()));
-        for(DataField field: CollectionUtils.emptyIfNull(dataTemplate.getFields())){
+        dataTemplate.setCommunity(communityRepository.findCommunityById(templateDto.getCommunityId()));
+        for (DataField field : CollectionUtils.emptyIfNull(dataTemplate.getFields())) {
             fieldRepository.saveAndFlush(field);
         }
         templateRepository.save(dataTemplate);
         return templateMapper.toResource(dataTemplate);
     }
 
-    public DataTemplateResource getCSDTemplate(UUID id) {
+    public DataTemplateResource getCSDTemplate(UUID id, UUID userId) {
         return templateMapper.toResource(templateRepository.findDataTemplateById(id));
     }
 
-    public Set<DataFieldResource> getFieldsOfCSDTemplate(UUID id) {
+    public Set<DataFieldResource> getFieldsOfCSDTemplate(UUID id, UUID userId) {
         return templateMapper.toResource(templateRepository.findDataTemplateById(id)).getFieldResources();
+    }
+
+    public List<DataTemplateResource> getCommunityTemplates(UUID communityId, UUID userId){
+        return templateMapper.toResource(templateRepository.findDataTemplatesByCommunity(communityRepository.findCommunityById(communityId)));
     }
 }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CSDataService.java
@@ -45,7 +45,6 @@ public class CSDataService {
 
         DataTemplate dataTemplate=templateMapper.toEntity(templateDto);
         dataTemplate.setCreator(userRepository.findUserById(templateDto.getUserId()));
-        dataTemplate.setCreator(userRepository.findUserById(templateDto.getUserId()));
         for(DataField field: CollectionUtils.emptyIfNull(dataTemplate.getFields())){
             fieldRepository.saveAndFlush(field);
         }

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CommunityService.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CommunityService.java
@@ -1,0 +1,47 @@
+package com.evteam.purposefulcommunitycloud.service;
+
+import com.evteam.purposefulcommunitycloud.mapper.CommunityMapper;
+import com.evteam.purposefulcommunitycloud.model.dto.CommunityDto;
+import com.evteam.purposefulcommunitycloud.model.entity.Community;
+import com.evteam.purposefulcommunitycloud.model.entity.User;
+import com.evteam.purposefulcommunitycloud.model.resource.CommunityResource;
+import com.evteam.purposefulcommunitycloud.repository.CommunityRepository;
+import com.evteam.purposefulcommunitycloud.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+/**
+ * Created by Emir Gökdemir
+ * on 17 Kas 2019
+ */
+@Service
+public class CommunityService {
+
+    @Autowired
+    private CommunityMapper mapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private CommunityRepository repository;
+
+    public CommunityResource createCommunity(CommunityDto dto, UUID userId) {
+        Community community = mapper.toEntity(dto);
+        User creator = userRepository.findUserById(userId);
+        community.setCreator(creator);
+        return mapper.toResource(repository.saveAndFlush(community));
+    }
+
+    public CommunityResource getCommunity(UUID communityId, UUID userId) {
+
+        Community community = repository.findCommunityById(communityId);
+        if (community.getIsPrivate() && community.getCreator().getId().equals(userId) ) {
+            throw new RuntimeException("Community is private");
+            // TODO: 17 Kas 2019 following mechanism will be added
+        }
+        return mapper.toResource(community);
+    }
+}

--- a/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CommunityService.java
+++ b/purposeful-community-cloud/src/main/java/com/evteam/purposefulcommunitycloud/service/CommunityService.java
@@ -10,6 +10,7 @@ import com.evteam.purposefulcommunitycloud.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.transaction.Transactional;
 import java.util.UUID;
 
 /**
@@ -28,6 +29,7 @@ public class CommunityService {
     @Autowired
     private CommunityRepository repository;
 
+    @Transactional
     public CommunityResource createCommunity(CommunityDto dto, UUID userId) {
         Community community = mapper.toEntity(dto);
         User creator = userRepository.findUserById(userId);
@@ -36,7 +38,6 @@ public class CommunityService {
     }
 
     public CommunityResource getCommunity(UUID communityId, UUID userId) {
-
         Community community = repository.findCommunityById(communityId);
         if (community.getIsPrivate() && community.getCreator().getId().equals(userId) ) {
             throw new RuntimeException("Community is private");


### PR DESCRIPTION
Community Specific Data Type initialized. 
Data Fields are defined.
One endpoint (create) is created.
Community Specific Data Type initialized.
Data Fields are defined.
One endpoint (create) is created.
Community Specific Data Type get and getfields methods are implemented.
Mapper class is edited
Merge branch 'StudentIdAndPhoneRemoving' into BackendCommunitySpecificDataTypeCreation
Community is created
Creation of community and get community endpoints are implemented
Get Community Templates is implemented 
Community is added to DataTemplate
